### PR TITLE
Improved sws downsampling

### DIFF
--- a/ipy_notebooks/keras_v05.ipynb
+++ b/ipy_notebooks/keras_v05.ipynb
@@ -1,0 +1,783 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Updated downsampling; removing group=7 (flawed) SWS spectra"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Specifically, was accidentally training NN on full dataset (!) instead of just training set. Oops."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1.10.0\n"
+     ]
+    }
+   ],
+   "source": [
+    "# TensorFlow and tf.keras\n",
+    "import tensorflow as tf\n",
+    "from tensorflow import keras\n",
+    "\n",
+    "# Helper libraries\n",
+    "import glob\n",
+    "import matplotlib.pyplot as plt\n",
+    "import numpy as np\n",
+    "import pandas as pd\n",
+    "from IPython.core.debugger import set_trace as st\n",
+    "from sklearn.model_selection import train_test_split\n",
+    "\n",
+    "print(tf.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dataset: ISO-SWS"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Needed directories\n",
+    "base_dir = '../data/isosws_atlas/'\n",
+    "\n",
+    "# Pickles containing our spectra in the form of pandas dataframes:\n",
+    "spec_dir = base_dir + 'spectra/'\n",
+    "spec_files = np.sort(glob.glob(spec_dir + '*.pkl'))\n",
+    "\n",
+    "# Metadata pickle (pd.dataframe). Note each entry contains a pointer to the corresponding spectrum pickle.\n",
+    "metadata = base_dir + 'metadata.pkl'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the metadata pickle.\n",
+    "meta = pd.read_pickle(metadata)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Remove entries in dataframe where group = 7 (fatally flawed)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "meta_clean = meta.query('group != \"7\"')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>ra</th>\n",
+       "      <th>dec</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>count</th>\n",
+       "      <td>1058.000000</td>\n",
+       "      <td>1058.000000</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>mean</th>\n",
+       "      <td>229.948241</td>\n",
+       "      <td>6.363673</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>std</th>\n",
+       "      <td>100.353651</td>\n",
+       "      <td>42.686995</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>min</th>\n",
+       "      <td>0.532083</td>\n",
+       "      <td>-79.646694</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>25%</th>\n",
+       "      <td>182.316469</td>\n",
+       "      <td>-28.996035</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>50%</th>\n",
+       "      <td>268.232292</td>\n",
+       "      <td>8.755458</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>75%</th>\n",
+       "      <td>300.364833</td>\n",
+       "      <td>46.367757</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>max</th>\n",
+       "      <td>359.603292</td>\n",
+       "      <td>89.264111</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "                ra          dec\n",
+       "count  1058.000000  1058.000000\n",
+       "mean    229.948241     6.363673\n",
+       "std     100.353651    42.686995\n",
+       "min       0.532083   -79.646694\n",
+       "25%     182.316469   -28.996035\n",
+       "50%     268.232292     8.755458\n",
+       "75%     300.364833    46.367757\n",
+       "max     359.603292    89.264111"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "meta_clean.describe()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Labels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Simple classifier first.\n",
+    "labels = meta_clean['group'].values.astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([1, 2, 3, 4, 5, 6])"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# The possible labels.\n",
+    "np.unique(labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# SHIFTING TO START AT ZERO!\n",
+    "labels = labels - 1"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Labels ('group'):\n",
+    "\n",
+    "1. Naked stars\n",
+    "2. Stars with dust\n",
+    "3. Warm, dusty objects\n",
+    "4. Cool, dusty objects\n",
+    "5. Very red objects\n",
+    "6. Continuum-free objects but having emission lines\n",
+    "7. Flux-free and/or fatally flawed spectra"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAW4AAAD8CAYAAABXe05zAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAIABJREFUeJzt3X1sHOedH/Dvb4ZDaZaxvaRNueKaa8WMINcJTdHZhpR5OMTuJczl7RhFsqOYaJAGVtu7oklz4CFChFoqFOiubBy3aHCI0txbrdP5HLs8wziUNRK3QX2RclQUm1FsniLHoUzlIjkSHVtcW6vl0z92ZzU7O6/LXZIP9f0AAsXZ5+33vPx2ubMSRSkFIiLSh7HSAyAiomSYuImINMPETUSkGSZuIiLNMHETEWmGiZuISDNM3EREmmHiJiLSDBM3EZFmWprR6E033aQ2bdrUjKaJiNak48ePv6aU6oxTtimJe9OmTZiammpG00REa5KI/DxuWb5VQkSkGSZuIiLNMHETEWmGiZuISDNM3EREmon1qRIReQXAGwCKAK4opXLNHJSfiRNz2PfUScznCzWPjQ5mcWCkt6rs+OQMzs7n0ZW2MTa8BSP9mbr7ak9ZeOhj7660MXFiDmOP/wiFxat1hno6cPjBbVV9r7cMvH1lEYuu31WRti2IAPMLhcixxYkjbF4MAbbd1oFXfpWvagNAYHxJ5s7btyHAogJMERSVqnwNi7metXLXuSFiPoPmx7umUX1cvlLEgnvBXdpaTXzlE72Y+vkFHDl2BkXXLyfJuObc3d6ltwtV+0cABP1KE/dYH/jm9/Hc6Qu+5bzzn/HMh7eus2fj2jsxXYnPFMGuge6qc+flzOHcfL4qvpRlYJ1lYn6hgPWWgbzPvHrH7m3Tu/YtBmrO485c1rf/qLXfOzGNR4/OBsa1rsXAztwtePal83XnmKWSOL8Bp5y4c0qp1+I0msvlVCM/DlhKlM+jsBg8Vid5T5yYw54np5EvFCuP2ZaJg9t7Y01sUF+WKRjf0QcA+MJjP/Ktu3lDG169+FZV31GCxhYnjjjz4mUZpUPtrWKZgvv/WTeeOD4Xa+7q6dvbJoDEa+U3L35tO09CYWN01jTO3C+FZQggQKFY/2+bskzBphtTOHXuUqJ6znw8PjXrm/DjJu+gZOZ90eRoxBz67fckbTpPZH6C1j4qaccdaz1E5HjcF8VavFUyPjkTmSCOHDtTKetd2HyhiPHJmSX1VSgqjE/OhLZz6tylxBs1aGxx4ogzL16FxdqkDZTiO3LsTOy5q6dvb5v1rJVfnaD6UWN01jRpH0kVFtWSkjZQGmvSpA1cnY+gV+lB172c8xX3eiPm0G+/J2kzbHsGrX1QPFGS5JhGiPsPcBSA/y0iCsA3lFKHvAVEZDeA3QCQzWYbN0IAZ+fzkWWcH0+DysZpI6pc3DaS8ms3ThyNHk8x4KevJOOLq955jtOvUyZJ2aR96KQR8QTtjSR7ph7N3O9+7QXFU297zRL3FfeQUuouAL8N4PdE5De9BZRSh5RSOaVUrrMz1r/ajK0rbUeWMUVCy8ZpI6pcV9qO3U4Sfm3GiaPRY3HmMM5Yltp32FxGrUGctpOWTdqHThoRT9DeSLJn6tHM/e7XXlA89bbXLLESt1LqbPnrOQD/E8D7mjkor7HhLaX3CUPsGuiulLUts+ox2zIrN4jq7csyBWPDW0Lb2byhrabvKEFjixNHnHnxsgyBXxXLLN1sijt39fTtbbOetfKrE1Q/aozOmibtIynLEFhm/QkBKI1184a2xPWc+Rjq6fB9POi6l3O+4l5vxBz67fckbYZtz6C1D4onSpIc0wiRiVtE2kTkOufvAD4I4MfNHpjbSH8G4zv7kLYt38fdN0hG+jM4uL0XmbQNQenudJKbBn59taesyo2Mkf4MHrl/KyzPzA31dOCZL76/qm/bMmo2T9q20J6yIscWJ46oeTGkNC53G+M7+/DwfVt94zsw0ht77vz6dmJ1XrU4X4NirmetvHXC5jNsftxrGqePlHfBXdpaTTxy/1aMDmZrXrE5cz6+o6+qPW9zYWndGeszX3x/aKL1zr97Pg4/uK2mbpJPlRwY6a2KzxQJvDEJVM+hN76UZVTWzA6Y16D9HrT2fufx4fu2+vYftvZOnGHWtRgYHczWnWMaIfJTJSJyG0qvsoHSe+J/qZT6SlidRn+qhIhorUvyqZLIm5NKqZcB9C15VERE1BBafByQiIiuYuImItIMEzcRkWaYuImINMPETUSkGSZuIiLNMHETEWmGiZuISDNM3EREmmHiJiLSDBM3EZFmmLiJiDTDxE1EpBkmbiIizTBxExFphombiEgzTNxERJph4iYi0gwTNxGRZpi4iYg0w8RNRKQZJm4iIs0wcRMRaYaJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkGSZuIiLNxE7cImKKyAkRebqZAyIionAtCcp+HsCLAK5v0lgwcWIO45MzODufR1faxj23d+Lp53+B+Xyhqlx7ysJH7tyIZ186j7n5PEwRFJVCJm1j0402jr58EUWlYIpg10A3Doz04oFvfh/Pnb5Q06cAMAQoqmZFVWIKcL1t4eJCoTJeywAKi/W1Z1sG3r6yiEVVisEyBZddQRgCLKrqcs585G7tqJrnseEtGOnPBPa1d2IaR46dQVFVT1J7ysIdG6/D352+gLjTJ+WxL9QbeFnKMrDOMjG/UMANtgUR4OJCIbJeJma8h4/Oxo6pXm2tJrrS63Hq3CXfx1OWgbcKi/CbqaGeDhx+cBuA0rnZ99TJyjlJWaXXY84cO3shzjlx81t3ASrz4l6D9ZaBfMCaGgL0dLbh5fMLKCoFAZBqNbFwuVg554/9YLbqLDjxTZyYw54nXwhs2z2Xly4XKzH6zdc7O99RFY8Ti9/58ZtnoDZHRe2lZhHlE2RNIZFbAPw5gK8A+KJS6qNh5XO5nJqamko0kNICTSNfKCaqF8fN17Xil29cbni7ujINQXHx6rrblomD23t9N+DeiWk8enR2OYfXdGsl3qGeDuzMZTH2+PMoLC79aWZ0MFtJ3qthHjZvaMPpc5d8n7iWU/WTSHWOCttLSYnIcaVULk7ZuG+VPALgD4DmzeH45ExTkjYAJm2PoueQ5wtFjE/O+JY9cuzMcgxpWa2VeJ87fQHjkzMNSdpAdeyrYR5OrYKkDaDyk7pfjgrbS80UmbhF5KMAzimljkeU2y0iUyIydf78+cQDOTufT1yHGido/v1+7FwL1kq8jTw37th1m4flEDTXK5G74rziHgLwcRF5BcBfAbhXRB71FlJKHVJK5ZRSuc7OzsQD6UrbietQ4wTNvymyzCNZHmsl3kaeG3fsus3Dcgia65XIXZGJWym1Ryl1i1JqE4BPAfiuUmq00QMZG94C2zIb3SyA0nvcdJVpVB9K2zIxNrzFt+yuge7lGNKyWivxDvV0YGx4CyyjMUnWHftqmIfNG9pWxeeVh3o6APjnqLC91EyrYV4AACP9GRzc3otM2oagdPd/dDCLtG3VlG1PWRgdzCJTfqZzXh1k0jaGejoq35siGB3M4tiXP1CZfC9B6RMfzWZKadzu8VpLmH3bMuCcVwHQ6gnCecxdzpmPr+7sq5rnsJsrB0Z6MTqY9X0F1p6yMNTTgSTTJ7j6qYelSFkG2lMWBEDatipzGyVuvMvxerOt1cTmDW2Bj6csI/CAOjfMRvozGN/ZV3VOUpZRNcfu9QeCz4n7UyVB6+7+zr0GdsiaGlJKwk5bUo7dfc691Yd6OvDMF9+Ph+/fGtq2o63VrIrRa6inoyYecX31nh93PedTJX45qlE3JpOK9amSpOr5VAkR0bWsGZ8qISKiVYKJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkGSZuIiLNMHETEWmGiZuISDNM3EREmmHiJiLSDBM3EZFmmLiJiDTDxE1EpBkmbiIizTBxExFphombiEgzTNxERJph4iYi0gwTNxGRZpi4iYg0w8RNRKQZJm4iIs0wcRMRaYaJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkmZaoAiKyHsD3AKwrl/+2UuqhZg1o78Q0Dh+dhfJcb09Z+MidG/HsS+dxdj6PrrSNseEtAIDxyRmcnc9jvWXg7SuLWFSAKYJdA904MNJbaWPixFyl7A22hctXilgoLFbaf+hj7w5szy1lGVhnmZhfKKArbeOe2ztrxjXSn6nps8UAyt01VFuria98orfSp7dfvzj85ieobj5k0ALUrJX7uimColLIpG2kWg2cOnep7jiTSlkGCsXFwDk3BPj0QBYHRnorMc/N56vKtBiCT72vG08cf9V3Htz7Zt9TJzGfL0SOa/OGNixcXsTcfL4yP1bCvVFPv0k4e2rq5xdw5NgZFJXfKoePy9lDYWfCfX68c+9Y12Ig22HX7B3v+rnnoT1l4Y6N1+Hoyxdjjd19Hrzjc/JM0DyvazFw+cpiTZzNJCoiKBERAG1KqTdFxALw/wB8Xil1NKhOLpdTU1NTiQezd2Iajx6djV3eMgQQoFAMjmF08OrC7nlyGvlCMbCsIYBpSGh7cdiWiYPbSwkxqs9GMQ3BV3f2YaQ/EytWhzM/jiR114qhng78cPb1umM2pPTV+wTfbCvVbxS/c9TMMzHU04Ef/OwiCg2YCL+9YBmlJ9c4zTtx1pO8ReS4UioXq2xU4vY0nEIpcf8bpdSxoHL1Ju6ePX8b+5k9LlMEpw9+GEN/+N3AZ/RmyKRtAFj2Pp/70r2JYnXmx7Hc80TXjpU4EyvBOYdJJUnckW+VlBs0ARwH8C4AX/dL2iKyG8BuAMhms/FH69LopO1u8+wyb5bl7s/dZ5K+vXO+EuOma8O1sreWI85YNyeVUkWl1FYAtwB4n4i8x6fMIaVUTimV6+zsrGswpkhd9eK02VV+tl8uXWl7Rfp0f43DO+fLPWa6dqzEmVgJyxFjok+VKKXmAfwfAB9qxmB2DXQnKm8ZAssMT/ZOm2PDW2BbZmhZQxDZXhy2ZWJseEusPhvFNKRyEyVJv945X84xrxZDPR1LitmQq+83L6eV6jeK3zlq5pkY6uko3e9qUFve8VmGxJ5nJ85mi0zcItIpIuny320AvwXgpWYM5sBIL0YHs/Cbo/aUhdHBLDJpG4LS+0jjO/swvqOvcs22jMoEmyJVN95G+jM4uL23UjZtW0hZRlX7D9+3NbA9t5RloD1lVcbhHZdzc8Lbp9WkD1+2tZqVG5N+sfrF4Z0fh1/dMEH72bnuvKLPpG1s3tCWLLAlSllG6JwbUro5e/jBbZWYvVqM0jwFzYOzbx6+byvSthVrXJs3tFX6cuYn6d6op98k2lpNPHL/VowOZhP9JOx3jsLOhPv8BFnXYvjuHff6je/sq5qH9pSFoZ6O2GN3zoN7L7jzTNg8r2sxauJstjifKrkTwJ8DMFFK9H+tlPqPYXXqvTlJRHStaujNSaXUCwD6lzwqIiJqCP7LSSIizTBxExFphombiEgzTNxERJph4iYi0gwTNxGRZpi4iYg0w8RNRKQZJm4iIs0wcRMRaYaJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkGSZuIiLNMHETEWmGiZuISDNM3EREmmHiJiLSDBM3EZFmmLiJiDTDxE1EpBkmbiIizTBxExFphombiEgzTNxERJph4iYi0gwTNxGRZiITt4h0i8izIvKiiJwUkc8vx8CIiMhfS4wyVwD8vlLqhyJyHYDjIvKMUuonTR5boIkTc9j31EnM5wsAAEOARQVk0jbGhrdgpD9TU358cgZn5/O4wbYgAswvFNDlKj9xYg57nnwB+cJipc1PD2RxYKS3qq29E9M4cuwMikrBFMGugW4cGOmt6qPLMw5vncHb2nHy7Buxxx82D0F9+j0GAOOTM5ibz8MUQVEp3z6j6jrc8ScZ56YbbRx9+SKKSi2prfWWgbevLGJRRdd36sUdv7u8e67uub0Tz7503nfOg+bO2V/uPWsZQHmrAQDaWk185RO9gXtm10A3crd2VLXtHcumG2383ekLUAFtOoL28N6JaTx6dLZSTgDc3dOBH87OV52Lbbd14JVf5WPtu6D52jsxjcNHZ2vGCiBwT8fZE3HOQZzHovoJyiPLRZTr8MSqIPI3AP6bUuqZoDK5XE5NTU0tdWy+Jk7MYezx51FY9B+3bZk4uL23anH2PDmNfKEYWP6T783gL4/OYtHn8dHBq8nbu7EdQz0d+OHs61V9OOOY+vkF3zpBvOMP4heXUxdAzWOWIYAAhWLtvLn79Gs3rC5QPUdxxhlmqW351Y+q562TZMxRc+fsr8d+cCZwzzpMQ/DVnX2Be8Y0BMWINoLadD8h+LW9eUMbTp27lKhtR9i+8yt7V/YGPHf6Qs1jAqDFlKp9FnUekp6DOI/59RUnj8Q5t2FE5LhSKherbJLELSKbAHwPwHuUUr8OKtfMxD30h9+tetXkJ5O28dyX7o1d3nlFFfTY6YMfBgD07PnbwHJB4/jH199KVMep54w/SFBcmbQNAJExB/UZZ7683HMUd5zNasuvflQ9b52kY46au7D95ddWPXsmzviA5Hs4SR9A8n0Xt+2g81DPOYh6zK+vpHmnHkkSd5y3SpxG3wHgCQBf8EvaIrIbwG4AyGazcZtN7GyMjeEuE6d82EZ2P5Z0w5+dz6OeI5I0xqR1w+rVUz9sXpK2t9S2/OpH1fPWSTrmqLlLsm/q3TNRbdYzlnr7WM626zkHjW4vSZlGifWpEhGxUErah5VST/qVUUodUkrllFK5zs7ORo6xSlf52TJumTjlTZFYj4WVCxpH0jpOvXrLdKXtWPWD2qunbliMSdtbalt+9aPqeeskHXPU3CXZA/Xumag26xlL0j7q2Ttx2076WNh4oh5LOoYkZRolzqdKBMC3ALyolHq4+UMKNza8pfSeawDbMis305zytmWGlt810B04EbsGun3/7jbU01HThzOOoDph43GPP4hfXE5dv8csQ2CZ/vPm7jNpXSB4XoLaC7PUtvzqR9Xz1kky5qi5c/ZX2J51mIaE7hkzRhtBbTqC2t68oS1x246wfedXdqinw/cxAWr2WdR5SHoO4jwWt58k42w0c9++faEF9u/f/xsAHgHQtn///n+1f//+f71///7Zffv2nQqqc+jQoX27d+9u7EjLbt94PbIdKRx9+Vd468rVO90KpfeY/sPH7qi6QXD7xutxS7uN6bnX8eZbV5C2LditJt4uLFbK/+4978KtN7bh//7DOVwp3/wxBHjAc9Pq3ttvxmtvvo2Tc7+GQunVywODWXz9gfdW9eEeh1+du3s68MZbV2KNP2wegvr0e2zfx9+ND97xTzA99zreeOsKTBHfPuPUdTjxh30SxK+9OzPX4+z8W1VvCdTTlm0ZWFSqai386rvrxRm/t7x7rn5naxd+9eblmjkPW5PfveddNXvWMkqfJHK0tZr4o0/eGbhnHhjM4rN3v7Oqbe9Y7sxcj1cv5n3bdAS1/WefHcBrb76NF159vVJWUHpR8tqbb1edi7t7OrCoEGvf+c3Xlz9yB157821Mu/pqazXxn3b0VfaZ3/zG2RNR44nzWJx+/PLIUj9Vsn///l/s27fvUJyyiT9VEkczb04SEa1FSW5O8l9OEhFphombiEgzTNxERJph4iYi0gwTNxGRZpi4iYg0w8RNRKQZJm4iIs0wcRMRaYaJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkGSZuIiLNMHETEWmGiZuISDNM3EREmmHiJiLSDBM3EZFmmLiJiDTDxE1EpBkmbiIizTBxExFphombiEgzTNxERJph4iYi0gwTNxGRZpi4iYg0w8RNRKSZlqgCIvInAD4K4JxS6j3NGsgD3/w+njt9IVZZQ4BPD2SRu7UD+546ifl8oaaMKUBR1TeWlGVgnWVifqGA9ZaBfGGxpkx7ysJDH3s3RvozAICJE3MYn5zB3Hy+qpwAuLunA6/8Ko+z83l0pW3cc3snnn3pfE1ZAGhrNXHpchECwD1895i60jbGhrcAgG+fQbxtmiLYNdCNAyO9lWt7J6bx6NFZ3/qGAIsKsAzAOyXrWgzkbk3XrGFbq4mFcjzuKjdf14oW06zMSVQ87SkLH7lzo++8OXGZIigqhUy5vZH+TGVd3P08PjVbM84WQ/Cp93Xj2ZfOV5UNasNZ96QmTswF7lng6hxnfPoJ2mNuadvC5StFLPjsWWct3DHsnZjG4aOzqPOowBCg8x2t+OUbl+ts4ap1LQZ25m4JPBsAMNTTgZNn3wicP6+oPGCK4LbOFF4+v4CiUjBFMHhbe9V5dfZm2Lr5jfPwg9tila2HKBW+ZCLymwDeBPAXcRN3LpdTU1NTsQeRJGlXjQ2oe8M1gmUKxnf0AQD2PDmNfKG4fH0bAghQqPfZyWV0MIsDI72hSbvZGhkPANiWiU++N4Mnjs/VvS5BbdiWiYPbexMn74kTcxh7/HkUFuPF6O5n4sRcQ/eYbZm4K3tDXefuWmMZpRcEMZetImnyFpHjSqlcnLKRb5Uopb4HoKmrW+/mWcmkDZSSzPjkDMYnZ5Y1aQNAYVE1LMkdOXam6utKaGQ8AJAvFHHk2JklrUtQG/lCEeOTM4nbG5+ciZ20vf00eo/lC0Um7ZgKi8mTNlB/Xosj8q2SuERkN4DdAJDNZhvV7Kp3NubbFKtZsfxTVzHipy/dNCKeoDbqWfel1FkL+4wap2E3J5VSh5RSOaVUrrOzs1HNrnpdaRtdaXulh7EkpkjV17WiEfEEtVHPmi+lju57jBprVXyqZKino656K51mLFMwNrwFY8NbYFvm8vZtCCyzMTOwa6C76utKaGQ8QOk93F0D3Utal6A2bMus3LBKYmx4S+m9/AT9O/00eo/Zlln3ubvWWIYgwbJVNHN+V0XiPvzgtkRBGlK6ofa1+7cibVu+ZZaSA1KWgfaUBQFgW/5T1J6yML6jDyP9GYz0Z3Bwey8yPq+KBKUFzKRtCEqfFhgdzPqWBUp3/p16QWPKpG2M7+zD+I6+wHb8eNs0RSo3JgHgwEgvRgeD3+ZyNq/flKxrMXzXsK3VhKB2o918XWvVnETF056yAufNict5dZxJ2zi4vRcHRnor6+L088j9W33H2WJIpX2JaKOeG5MAMNKfwfjOvsA9C1ydY28/YXvMLW1bSAXsWWctnLYPP7gNo4PZJb0AMqS0lo2wrsUIPRtA6SyFzZ9XVB4wRbB5Q1vVT53e8zq+sw8P3xeca4LGudKfKjkC4P0AbgLwSwAPKaW+FVYn6adKiIiudUk+VRJ5c1IptWvpQyIiokZZFW+VEBFRfEzcRESaYeImItIMEzcRkWaYuImINMPETUSkGSZuIiLNMHETEWmGiZuISDNM3EREmmHiJiLSDBM3EZFmmLiJiDTDxE1EpBkmbiIizTBxExFphombiEgzTNxERJph4iYi0gwTNxGRZpi4iYg0w8RNRKQZJm4iIs0wcRMRaYaJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkmViJW0Q+JCIzIvJTEflSswdFRETBWqIKiIgJ4OsAPgDgVQB/LyJPKaV+0ujB7J2YxuGjs1Dl79taTXSl1+PUuUs1ZW3LQL6wWHWt1RRcLqqask5bly4XIQD8S1yVskrPZwvl9lOWgXWWiYsLhar67SkLD33s3Rjpz9S0MXFiDuOTM5ibz/v24bSTSdu45/ZOPPvSeZydz+MG24IIML9QQJfrsbn5PEwRFFX46E0BAqagITJpG2PDW3xjdkycmMO+p05iPl+oXHPm6vGpWTx3+kLl+s3XteK1NwsoKgVTBLsGupG7tQPjkzM4O59HV7k/AIFtho0laEztKQt3bLyuaixeo4NZHBjpraylezzePt3r7ayT31ztnZjGkWNnquI9MNJb1c6eJ1+o7G1DgE8PZKvKhMVlCLCoqtcpbC+2tZrY2n0Djr58EUWlIABSrSYWLhdr9qKzDmH72s0yAM8RRVuriU/clcHTz/+iai3CzpF33cLWfO/ENB49Olv5XgA8MJit7Kk44/abc789ACDR2BpJVEQiEJFtAPYppYbL3+8BAKXUwaA6uVxOTU1NJRqId8J1YZmC8R19VYtVOnzTyBeKKziy5rEtEwe39wYetLHHn0dhsf5nD9MQFF31LaOUCP2a9Jv/Ro5pqKcDP5x9vWotvfGHrbe7bNAedz9BfPGxH2GxpsTVMknisi0Tn3xvBk8cn2vIXrQMAQQoNOGVQdA58osvaM3Dcoh3T8XhXhfv+gbtyTj7MYiIHFdK5eKUjfNWSQbAGdf3r5avNdSRY2eiC61ChaLC+ORM1bXxyZk1m7QBIF8o1sTsGJ+cWVLSBlBzwAqL/kkb8J//Ro7pudMXatbSG3/YervLBu1x5/r45Ixv0g6qGxVXvlDEkWNnGrYXC4uqKUkbCD5HfvEFrXlYDkmatN3t+a1v0J6Msx8bIU7iFp9rNUMWkd0iMiUiU+fPn088kKi3AFazs54fv7zfr0VBMa5E7FF9NmNM7jbj9h+0x53rYe341Y0Tl07nKsk58nus0bHGWRc/y3EG4iTuVwF0u76/BcBZbyGl1CGlVE4plevs7Ew8EFP8nh/00JW2Q79fi4JiXInYo/psxpjcbcbtP2iPO9fD2vGrGycunc5VknPk91ijY42zLn6W4wzESdx/D2CziLxTRFoBfArAU40eyK6B7uhCq5BlSuVGhWNseAtsy1yhETWfbZk1MTvGhreU3gtdAtNT3zIEQU36zX8jxzTU01Gzlt74w9bbXTZojzvXx4a3BB5Iv7pRcdmWiV0D3Q3bi5YhsMzmPBEEnSO/+ILWPCyHePdUHO518c5h0J6Msx8bITJxK6WuAPi3ACYBvAjgr5VSJxs9kAMjvRgdzFa9L9PWamLzhjbf8rZVO/TWkE3V1lqa+DjLl7KMyidLnO/bU1ZN/faU5XsjYqQ/g4Pbe5EJeeZ12smkbYwOZpFJ2xAAadtCe8qCeB4D4r2iaNK5qsik7cAbk0Ap9vGdfUjbVtX19pSFR+7fiqGejqrrN1/XWokshNOrAAAFRUlEQVTLFMHoYBZf3dlXmY9M2sb4zj48fN9W3zbj3AjyG1N7yqoZi9foYBaHH9xWWUtnPN74vevtxOMt6+xxb7zOTceR/gwevn9r1d42xP/GZFBcTjJx+j4w0hu6F9taTQz1dFTGJOVrfntxfGcfxnf0he5rN58jirZWE6OD2Zq1CDpHfusWtObO/LoJULWn4vDOuXt9w/Zk3P3YCJGfKqlHPZ8qISK6ljX6UyVERLSKMHETEWmGiZuISDNM3EREmmHiJiLSTFM+VSIi5wH8vM7qNwF4rYHDWY2uhRgBxrmWXAsxAisb561KqVj/erEpiXspRGQq7kdidHUtxAgwzrXkWogR0CdOvlVCRKQZJm4iIs2sxsR9aKUHsAyuhRgBxrmWXAsxAprEuere4yYionCr8RU3ERGFWDWJey39QmIR6RaRZ0XkRRE5KSKfL1/vEJFnRORU+Wt7+bqIyH8tx/6CiNy1shHEJyKmiJwQkafL379TRI6VY3ys/F8BQ0TWlb//afnxTSs57iREJC0i3xaRl8prum2traWI/PvyXv2xiBwRkfVrYS1F5E9E5JyI/Nh1LfHaichnyuVPichnViIWt1WRuF2/kPi3AdwBYJeI3LGyo1qSKwB+Xyn1TwEMAvi9cjxfAvAdpdRmAN8pfw+U4t5c/rMbwB8v/5Dr9nmU/rtfxx8B+Fo5xosAPle+/jkAF5VS7wLwtXI5XfwXAP9LKXU7gD6U4l0zaykiGQD/DkBOKfUeACZK/+/+WljLPwPwIc+1RGsnIh0AHgIwAOB9AB5ykv2KUUqt+B8A2wBMur7fA2DPSo+rgfH9DYAPAJgBsLF8bSOAmfLfvwFgl6t8pdxq/oPSb0P6DoB7ATyN0n9//BqAFu+6ovT/uW8r/72lXE5WOoYYMV4P4Gfesa6ltcTV3yvbUV6bpwEMr5W1BLAJwI/rXTsAuwB8w3W9qtxK/FkVr7ixTL+QeCWUf4zsB3AMwM1KqV8AQPnrhnIxXeN/BMAfAJXfcXsjgHlV+uUbQHUclRjLj79eLr/a3QbgPIA/Lb8l9N9FpA1raC2VUnMA/jOAWQC/QGltjmPtraUj6dqtujVdLYk71i8k1o2IvAPAEwC+oJT6dVhRn2urOn4R+SiAc0qp4+7LPkVVjMdWsxYAdwH4Y6VUP4BLuPqjtR/t4iz/2P87AN4JoAtAG0pvG3jpvpZRguJadfGulsQd6xcS60RELJSS9mGl1JPly78UkY3lxzcCOFe+rmP8QwA+LiKvAPgrlN4ueQRAWkRaymXccVRiLD9+A4ALyzngOr0K4FWl1LHy999GKZGvpbX8LQA/U0qdV0oVADwJ4G6svbV0JF27VbemqyVxL8svJF4uIiIAvgXgRaXUw66HngLg3JH+DErvfTvX/0X5rvYggNedH+VWK6XUHqXULUqpTSit13eVUg8AeBbAjnIxb4xO7DvK5Vf9qzSl1D8COCMizm+A/ecAfoI1tJYovUUyKCKp8t51YlxTa+mSdO0mAXxQRNrLP518sHxt5az0jQPXG/4fBvAPAE4D+PJKj2eJsfwGSj9KvQDgR+U/H0bpfcDvADhV/tpRLi8ofarmNIBplO7ur3gcCeJ9P4Cny3+/DcAPAPwUwOMA1pWvry9//9Py47et9LgTxLcVwFR5PScAtK+1tQSwH8BLAH4M4H8AWLcW1hLAEZTety+g9Mr5c/WsHYB/WY73pwA+u9Jx8V9OEhFpZrW8VUJERDExcRMRaYaJm4hIM0zcRESaYeImItIMEzcRkWaYuImINMPETUSkmf8PlHahk1z+f3cAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# See how the labels are distributed.\n",
+    "plt.plot(labels, 'o');"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(numpy.int64, 1058)"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(labels[0]), len(labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Make sure each sample has a valid label.\n",
+    "np.sum(np.isfinite(labels)) == len(labels)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# knowing that each sample has a 359-point vector/spectrum.\n",
+    "features = np.zeros((len(labels), 359))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Features"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def load_spectrum(path):\n",
+    "    df = pd.read_pickle(path)\n",
+    "    flux = df['flux']\n",
+    "    return flux / np.nanmax(flux)\n",
+    "\n",
+    "index = 0\n",
+    "# Fill the 'spectra' variable with the astronomical data.\n",
+    "for row in meta_clean.itertuples(index=True, name='Pandas'):\n",
+    "    flux = load_spectrum(base_dir + row.file_path)\n",
+    "    features[index] = flux\n",
+    "    index += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(1058, 359)"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "features.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Split into training and test sets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Data as...\n",
+    "- features (1058, 359)\n",
+    "- labels (1058)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X_train, X_test, y_train, y_test = \\\n",
+    "train_test_split(features, labels, test_size=0.40, random_state = 22)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(634, 359)"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_train.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(424, 359)"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "X_test.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(634,)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_train.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(424,)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "y_test.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Extra optional scaling"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import preprocessing\n",
+    "\n",
+    "scaler = preprocessing.StandardScaler().fit(X_train)\n",
+    "X_train_scaled = scaler.transform(X_train)\n",
+    "X_test_scaled = scaler.transform(X_test)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model 1. Neural network"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "_________________________________________________________________\n",
+      "Layer (type)                 Output Shape              Param #   \n",
+      "=================================================================\n",
+      "dense_16 (Dense)             (None, 64)                23040     \n",
+      "_________________________________________________________________\n",
+      "dense_17 (Dense)             (None, 64)                4160      \n",
+      "_________________________________________________________________\n",
+      "dense_18 (Dense)             (None, 64)                4160      \n",
+      "_________________________________________________________________\n",
+      "dense_19 (Dense)             (None, 64)                4160      \n",
+      "_________________________________________________________________\n",
+      "dense_20 (Dense)             (None, 7)                 455       \n",
+      "=================================================================\n",
+      "Total params: 35,975\n",
+      "Trainable params: 35,975\n",
+      "Non-trainable params: 0\n",
+      "_________________________________________________________________\n",
+      "Test loss: 0.5390061364983613\n",
+      "Test accuracy: 0.8231132075471698\n"
+     ]
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD8CAYAAAB5Pm/hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAF1NJREFUeJzt3Xt0VeW57/HvI4TDzdYCsRtFSGRza2FwabwgaBXkJgxUauulSvCwiw7bqrubKjrqpVtrqXCo9qg4oiBYJGBRIopyAJVjYSiQQNRIxAAGiSggCAbkzrP/yCIlGkOyLizWm99nDMZac6455/vMleFvvb5rrneauyMiIuE6JdkFiIhIYinoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwDVMdgEArVq18oyMjGSXISKSUgoKCr5w9/TjbXdSBH1GRgb5+fnJLkNEJKWY2cbabKehGxGRwCnoRUQCp6AXEQncSTFGL6nn4MGDlJWVsW/fvmSXIjFq3Lgxbdq0IS0tLdmlSIIo6CUqZWVlnHrqqWRkZGBmyS5HouTubN++nbKyMjIzM5NdjiSIhm4kKvv27aNly5YK+RRnZrRs2VL/ZxY4Bb1ETSEfBv0dw3fcoDezqWa21cyKjlnXwswWmVlJ5PEHkfVmZn8zs3Vm9p6Z9Upk8SIicny1GaOfBjwGPHvMunHA6+4+3szGRZbvBIYAHSL/zgMmRx4lcBnj5sf1eKXjh9Zqu7lz5zJixAiKi4vp3LlzjdtOmzaNgQMHcsYZZ0RV05IlS5g4cSKvvPJKrdZ/s+38/Hwee+yxWrd39IeErVq1iqpekaOOG/Tu/paZZXxj9eXAxZHn04ElVAT95cCzXnHH8XfM7DQza+3un8WrYAFmXp28tq+bnby2q5Gbm0vfvn2ZNWsW999/f43bTps2ja5du0Yd9CKpKtox+h8eDe/I4+mR9WcCm47ZriyyTiTudu/ezbJly5gyZQqzZs2q8trDDz9Mt27d6N69O+PGjWPOnDnk5+fzy1/+kh49erB3714yMjL44osvAMjPz+fiiy8GYMWKFVxwwQX07NmTCy64gLVr19a6ppr23bRpE4MHD6ZTp0788Y9/rFw/Y8YMzj33XHr06MFNN93E4cOHqxxzz549DB06lO7du9O1a1dmzz65Pmzl5Bfvyyur+1bHq93QbAwwBqBt27ZxLkPqg7y8PAYPHkzHjh1p0aIFq1atolevXrz22mvk5eWxfPlymjZtyo4dO2jRogWPPfYYEydOJCsrq8bjdu7cmbfeeouGDRuyePFi7r77bl544YVa1VTTvitWrKCoqIimTZtyzjnnMHToUJo1a8bs2bNZtmwZaWlp3HLLLTz33HOMHDmy8pgLFizgjDPOYP78iuGxXbt2RfmOSX0VbdBvOTokY2atga2R9WXAWcds1wbYXN0B3D0HyAHIysqq9sNApCa5ubncfvvtAFxzzTXk5ubSq1cvFi9ezI033kjTpk0BaNGiRZ2Ou2vXLrKzsykpKcHMOHjwYFz2HTBgAC1btgRgxIgRLF26lIYNG1JQUMA555wDwN69ezn99NOrHLNbt26MHTuWO++8k2HDhnHhhRfW6XxEog36eUA2MD7y+NIx639jZrOo+BJ2l8bnJRG2b9/OG2+8QVFREWbG4cOHMTMefvhh3L1Wlww2bNiQI0eOAFS5jvyee+7hkksuYe7cuZSWllYO6dRGTft+syYzw93Jzs7mz3/+83ces2PHjhQUFPDqq69y1113MXDgQO69995a1yRSm8src4G3gU5mVmZmo6kI+AFmVgIMiCwDvApsANYBTwG3JKRqqffmzJnDyJEj2bhxI6WlpWzatInMzEyWLl3KwIEDmTp1Kl9//TUAO3bsAODUU0+lvLy88hgZGRkUFBQAVBma2bVrF2eeWfHV0rRp0+pUV037Llq0iB07drB3717y8vLo06cP/fv3Z86cOWzdurWy1o0bq848u3nzZpo2bcr111/P2LFjWbVqVZ1qEqnNVTfXfsdL/avZ1oFfx1qUpJ7aXg4ZL7m5uYwbN67Kup/97GfMnDmTyZMnU1hYSFZWFo0aNeKyyy7joYceYtSoUdx88800adKEt99+m/vuu4/Ro0fz0EMPcd55/7oK+I477iA7O5tJkybRr1+/OtVV0759+/blhhtuYN26dVx33XWV3xU8+OCDDBw4kCNHjpCWlsbjjz9Ou3btKvd7//33+f3vf88pp5xCWloakydPruvbJfWcVWRzcmVlZbluPFIHJ8HllcXFxXTp0iV5dUhc6e+ZmsyswN1rvroATYEgIhI8Bb2ISOAU9CIigVPQi4gETkEvIhI4Bb2ISOB0K0GJj3hf8lmLWTIbNGhAt27dOHToEF26dGH69OmV0x7U1bFTDc+bN481a9Z86zr9o3bu3MnMmTO55Za6/R7w/vvvp3nz5owdO7ZW6481atQohg0bxlVXXVWrtkpLSxk2bBhFRUXH31iCpx69pKwmTZpQWFhIUVERjRo14sknn6zyurtXTnFQF8OHD//OkIeKoH/iiSfqfFyRZFGPPgUtLt6StLYvTVrLNbvwwgt57733KC0tZciQIVxyySW8/fbb5OXlsXbtWu677z72799P+/bteeaZZ2jevDkLFizg9ttvp1WrVvTq9a+boR17k5AtW7Zw8803s2HDBgAmT57M3/72N9avX0+PHj0YMGAAEyZMYMKECTz//PPs37+fK6+8snIa4j/96U88++yznHXWWaSnp/OTn/ykxvN46qmnyMnJ4cCBA/x729b8/YmJNG3aBPaXs/iVF3n0//yFLVu/YNIDdzNsUD8OHz7MuP+ewJJly9l/4AC//t/Xc9Ooa+HLMjh8ALav54MPP+LG347jwMGDHDlyhBeeeZwO7TOqNrxnG8y8v+L5SXbPAYmdevSS8g4dOsRrr71Gt27dAFi7di0jR45k9erVNGvWjAcffJDFixezatUqsrKymDRpEvv27eNXv/oVL7/8Mv/85z/5/PPPqz32rbfeyk9/+lPeffddVq1axY9//GPGjx9P+/btKSwsZMKECSxcuJCSkhJWrFhBYWEhBQUFvPXWWxQUFDBr1ixWr17Niy++yMqVK497LiNGjGDlypW8++67dOnYninP/aPytdJNZfz/eTOZn/s0N4+9h3379jNlxj/4/vdOZeXiuaxc9CJP/X02H2/cVOWYT07L5bYx2RQueZn8xXNpc8a/xfBuSypSj15S1t69e+nRowdQ0aMfPXo0mzdvpl27dpx//vkAvPPOO6xZs4Y+ffoAcODAAXr37s2HH35IZmYmHTp0AOD6668nJyfnW2288cYbPPtsxV00GzRowPe//32+/PLLKtssXLiQhQsX0rNnT6DihiglJSWUl5dz5ZVXVn5vMHz48OOeU1FREX/4wx/YuXMnu7/ayaBL/jUl8S8uv4xTTjmFDu0zOLtdWz4sWc/CJf/kvQ/WMuflBQDs+qqckg2ldGyfWblf76ye/OmvT1D22eeMGDro2715CZ6CXlLW0TH6b2rWrFnlc3dnwIAB5ObmVtmmsLCwVlMZ14a7c9ddd3HTTTdVWf/II4/UuY1Ro0aRl5dH9+7dmfbYwyxZtrzyteqnOYb/O/5eBvW7qMprpZ+UVT6/7qrhnPeT7sxftIRBv7iRp//6EP0u6l2nuiS1aehGgnb++eezbNky1q1bB8DXX3/NRx99ROfOnfn4449Zv349wLc+CI7q379/5WyRhw8f5quvvvrWdMeDBg1i6tSp7N69G4BPP/2UrVu3ctFFFzF37lz27t1LeXk5L7/88nHrLS8vp3Xr1hw8eJDn5syr8to/5r3GkSNHWP/xRjZs/IRO/342gy65kMnPzKy8wclH6z5mz56vq+y3ofQTzs5oy61jshk+uD/vrfmwNm+dBEQ9eomPk/QLvPT0dKZNm8a1117L/v37gYppgTt27EhOTg5Dhw6lVatW9O3bt9pLER999FHGjBnDlClTaNCgAZMnT6Z379706dOHrl27MmTIECZMmEBxcTG9e1f0kps3b86MGTPo1asXV199NT169KBdu3a1ujPUAw88wHnnnUe7du3o1uFsynfvqXytU/tMfjr8OrZs/YInJz5A48b/i/+44ReUbiqjV7/LcXfSW7Yg7+9Vrz6anTefGf94ibS0NP7t9FbcO/Y3sbylkoI0TXEKWnzPxUlr+9IHlgCa1vaE2L7+hDVV/PGndPno8YqFZH5oJ2sK7pO0o3I8mqZYREQADd2IyEkkWb8ROVl/HxIv6tFL1E6GYT+JnbuD/pZBU9BLVBo3bsz27dsV9inO3dlevo/G+7cluxRJIA3dSFTatGlDWVkZ27YpIBJmzwl4b91pvH8bbT6dn/i2JGkU9BKVtLQ0MjMzj7+hRO/o3DMiMdLQjYhI4NSjFzlJ6QoUiRf16EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcDFFPRm9p9m9oGZFZlZrpk1NrNMM1tuZiVmNtvMGsWrWBERqbuog97MzgRuBbLcvSvQALgG+AvwV3fvAHwJjI5HoSIiEp1Yh24aAk3MrCHQFPgM6AfMibw+HbgixjZERCQGUQe9u38KTAQ+oSLgdwEFwE53PxTZrAw4M9YiRUQkerEM3fwAuBzIBM4AmgFDqtm02jtTmNkYM8s3s3zNaS4ikjixDN1cCnzs7tvc/SDwInABcFpkKAegDbC5up3dPcfds9w9Kz09PYYyRESkJrEE/SfA+WbW1MwM6A+sAd4Eropskw28FFuJIiISi1jG6JdT8aXrKuD9yLFygDuB35nZOqAlMCUOdYqISJRiuvGIu98H3PeN1RuAc2M5roiIxI9+GSsiEjgFvYhI4BT0IiKBU9CLiAROQS8iEriYrro5Kcy8OnltXzc7eW2LiNSSevQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISuJSf62Zx8ZaktX1p0loWEak99ehFRAKnoBcRCZyCXkQkcAp6EZHAKehFRAKnoBcRCZyCXkQkcAp6EZHAKehFRAKnoBcRCZyCXkQkcAp6EZHAKehFRAKnoBcRCVxMQW9mp5nZHDP70MyKzay3mbUws0VmVhJ5/EG8ihURkbqLtUf/KLDA3TsD3YFiYBzwurt3AF6PLIuISJJEHfRm9j3gImAKgLsfcPedwOXA9Mhm04ErYi1SRESiF0uP/mxgG/CMma02s6fNrBnwQ3f/DCDyeHoc6hQRkSjFEvQNgV7AZHfvCeyhDsM0ZjbGzPLNLH/btm0xlCEiIjWJJejLgDJ3Xx5ZnkNF8G8xs9YAkcet1e3s7jnunuXuWenp6TGUISIiNYk66N39c2CTmXWKrOoPrAHmAdmRddnASzFVKCIiMWkY4/6/BZ4zs0bABuBGKj48njez0cAnwM9jbENERGIQU9C7eyGQVc1L/WM5roiIxI9+GSsiEjgFvYhI4BT0IiKBU9CLiAROQS8iEjgFvYhI4BT0IiKBU9CLiAROQS8iErhYp0AQEUl5GePmJ63t0vFDE96GevQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgdOMREan3nk6bkMTWdeMRERGJkYJeRCRwCnoRkcAp6EVEAqegFxEJXMxBb2YNzGy1mb0SWc40s+VmVmJms82sUexliohItOLRo78NKD5m+S/AX929A/AlMDoObYiISJRiCnoza0PFRaBPR5YN6AfMiWwyHbgiljZERCQ2sfboHwHuAI5EllsCO939UGS5DDgzxjZERCQGUQe9mQ0Dtrp7wbGrq9nUv2P/MWaWb2b527Zti7YMERE5jlh69H2A4WZWCsyiYsjmEeA0Mzs6tUIbYHN1O7t7jrtnuXtWenp6DGWIiEhNog56d7/L3du4ewZwDfCGu/8SeBO4KrJZNvBSzFWKiEjUEnEd/Z3A78xsHRVj9lMS0IaIiNRSXGavdPclwJLI8w3AufE4roiIxE6/jBURCZyCXkQkcAp6EZHAKehFRAKnoBcRCZyCXkQkcAp6EZHAxeU6epFEyxg3Pyntlo4fmpR2ReJJPXoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwUQe9mZ1lZm+aWbGZfWBmt0XWtzCzRWZWEnn8QfzKFRGRuoqlR38I+C937wKcD/zazH4EjANed/cOwOuRZRERSZKog97dP3P3VZHn5UAxcCZwOTA9stl04IpYixQRkejFZYzezDKAnsBy4Ifu/hlUfBgAp8ejDRERiU7DWA9gZs2BF4Db3f0rM6vtfmOAMQBt27aNtQwJ3NNpE5LU8tAktSsSPzH16M0sjYqQf87dX4ys3mJmrSOvtwa2Vrevu+e4e5a7Z6Wnp8dShoiI1CCWq24MmAIUu/ukY16aB2RHnmcDL0VfnoiIxCqWoZs+wA3A+2ZWGFl3NzAeeN7MRgOfAD+PrUQREYlF1EHv7kuB7xqQ7x/tcUVEJL70y1gRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCQl6MxtsZmvNbJ2ZjUtEGyIiUjtxD3ozawA8DgwBfgRca2Y/inc7IiJSO4no0Z8LrHP3De5+AJgFXJ6AdkREpBYSEfRnApuOWS6LrBMRkSQwd4/vAc1+Dgxy9/+ILN8AnOvuv/3GdmOAMZHFTsDaKJtsBXwR5b6pSudcP+ic64dYzrmdu6cfb6OGUR68JmXAWccstwE2f3Mjd88BcmJtzMzy3T0r1uOkEp1z/aBzrh9OxDknYuhmJdDBzDLNrBFwDTAvAe2IiEgtxL1H7+6HzOw3wP8DGgBT3f2DeLcjIiK1k4ihG9z9VeDVRBy7GjEP/6QgnXP9oHOuHxJ+znH/MlZERE4umgJBRCRwKR309W2qBTObamZbzawo2bWcKGZ2lpm9aWbFZvaBmd2W7JoSzcwam9kKM3s3cs5/THZNJ4KZNTCz1Wb2SrJrORHMrNTM3jezQjPLT2hbqTp0E5lq4SNgABWXdK4ErnX3NUktLIHM7CJgN/Csu3dNdj0ngpm1Blq7+yozOxUoAK4I/O9sQDN3321macBS4DZ3fyfJpSWUmf0OyAK+5+7Dkl1PoplZKZDl7gn/3UAq9+jr3VQL7v4WsCPZdZxI7v6Zu6+KPC8Hign8l9ZeYXdkMS3yLzV7ZLVkZm2AocDTya4lRKkc9JpqoZ4xswygJ7A8uZUkXmQYoxDYCixy99DP+RHgDuBIsgs5gRxYaGYFkZkCEiaVg96qWRd0r6c+M7PmwAvA7e7+VbLrSTR3P+zuPaj4Zfm5ZhbsUJ2ZDQO2untBsms5wfq4ey8qZvr9dWRoNiFSOehrNdWCpL7IOPULwHPu/mKy6zmR3H0nsAQYnORSEqkPMDwyZj0L6GdmM5JbUuK5++bI41ZgLhXD0QmRykGvqRbqgcgXk1OAYneflOx6TgQzSzez0yLPmwCXAh8mt6rEcfe73L2Nu2dQ8d/xG+5+fZLLSigzaxa5uAAzawYMBBJ2NV3KBr27HwKOTrVQDDwf+lQLZpYLvA10MrMyMxud7JpOgD7ADVT08goj/y5LdlEJ1hp408zeo6JDs8jd68Ulh/XID4GlZvYusAKY7+4LEtVYyl5eKSIitZOyPXoREakdBb2ISOAU9CIigVPQi4gETkEvIhI4Bb2ISOAU9CIigVPQi4gE7n8A1db/n7zFjAUAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Sequential model, 7 classes of output.\n",
+    "model = keras.Sequential()\n",
+    "model.add(keras.layers.Dense(64, activation='relu', input_dim=359))\n",
+    "model.add(keras.layers.Dense(64, activation='relu'))\n",
+    "model.add(keras.layers.Dense(64, activation='relu'))\n",
+    "model.add(keras.layers.Dense(64, activation='relu'))\n",
+    "model.add(keras.layers.Dense(7, activation='softmax'))\n",
+    "\n",
+    "# Early stopping condition.\n",
+    "callback = [tf.keras.callbacks.EarlyStopping(monitor='acc', patience=4, verbose=0)]\n",
+    "\n",
+    "# Recompile model and fit.\n",
+    "model.compile(optimizer=tf.train.AdamOptimizer(0.0005),\n",
+    "              loss='sparse_categorical_crossentropy',\n",
+    "              metrics=['accuracy'])\n",
+    "model.fit(X_train, y_train, epochs=500, batch_size=32, callbacks=callback, verbose=False)\n",
+    "\n",
+    "# Summary\n",
+    "model.summary()\n",
+    "\n",
+    "# Check accuracy.\n",
+    "score = model.evaluate(X_test, y_test, verbose=0)\n",
+    "print('Test loss:', score[0])\n",
+    "print('Test accuracy:', score[1])\n",
+    "\n",
+    "# Check predictions.\n",
+    "predictions = model.predict(X_test)\n",
+    "predicted_groups = [np.argmax(x) for x in predictions]\n",
+    "plt.hist(y_test, label='Actual labels');\n",
+    "plt.hist(predicted_groups, label='Predicted labels', alpha=0.7);\n",
+    "plt.legend(loc=0);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model 2. k-nearest neighbours (KNN)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "http://scikit-learn.org/stable/tutorial/statistical_inference/supervised_learning.html#nearest-neighbor-and-the-curse-of-dimensionality"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import linear_model\n",
+    "from sklearn.neighbors import KNeighborsClassifier"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "KNeighborsClassifier(algorithm='auto', leaf_size=30, metric='minkowski',\n",
+       "           metric_params=None, n_jobs=1, n_neighbors=5, p=2,\n",
+       "           weights='uniform')"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "knn = KNeighborsClassifier()\n",
+    "# knn.fit(X_train, y_train)\n",
+    "knn.fit(X_train_scaled, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test accuracy: 0.7476415094339622\n"
+     ]
+    }
+   ],
+   "source": [
+    "predicted_labels = knn.predict(X_test_scaled)\n",
+    "test_acc = np.sum(predicted_labels == y_test) / len(y_test)\n",
+    "print('Test accuracy:', test_acc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD8CAYAAAB5Pm/hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAF/xJREFUeJzt3Xt0ldWd//H3VwgTQUcLxBaJJdjFrQUDWQFEQK0ooLBQUesdcGjRRR311x8odNpiV9Uy4nLs1BaKwgQXGLAIeEGdgEoptAIJRIwEDGCUFAsIgqBQuXznj3NIA4ZczsnhJDuf11qsc57r/j5J/WR3n+fZx9wdEREJ1xnJLkBERBJLQS8iEjgFvYhI4BT0IiKBU9CLiAROQS8iEjgFvYhI4BT0IiKBU9CLiASuabILAGjdurVnZGQkuwwRkQaloKDgU3dPq26/ehH0GRkZ5OfnJ7sMEZEGxcw+qsl+1Q7dmNlMM9tpZkUV1k0xs41mtt7MFprZuRW2TTSzzWa2ycwGxVa+iIjUlZqM0ecAg09atwTo6u4XAR8AEwHM7LvALcD3osf83sya1Fm1IiJSa9UGvbsvB/actC7P3Y9EF98B0qPvrwXmuvs/3P1DYDPQqw7rFRGRWqqLMfp/A+ZF37clEvzHlUXXfY2ZjQHGAHz729/+2vbDhw9TVlbGoUOH6qBESabU1FTS09NJSUlJdikijVJcQW9m/wEcAeYcX1XJbpVOeO/u04HpANnZ2V/bp6ysjLPPPpuMjAzMKjutNATuzu7duykrK6N9+/bJLkekUYr5PnozGwkMBW73f357SRlwQYXd0oHtsZz/0KFDtGrVSiHfwJkZrVq10v8zE0mimILezAYDDwHD3P3LCpteBm4xs38xs/ZAB2B1rMUp5MOg36NIclU7dGNmucDlQGszKwMmEbnL5l+AJdH/iN9x93vc/X0zewHYQGRI58fufjRRxYuISPWqDXp3v7WS1TOq2P9R4NF4iqpMxoTFdXq+0slDarTfwoULGT58OMXFxXTu3LnKfXNychg4cCDnn39+TDUtW7aMJ554gldffbVG609uOz8/n6effrrG7R1/UK1169Yx1SsiDUO9eDK2PsvNzaVfv37MnTuXhx9+uMp9c3Jy6Nq1a8xBL9LoPX9zctq9bV71+zRgmtSsCgcOHGDlypXMmDGDuXPnnrDt8ccfp1u3bmRmZjJhwgTmz59Pfn4+t99+O927d+fgwYNkZGTw6aefApCfn8/ll18OwOrVq7nkkkvo0aMHl1xyCZs2bapxTVUdu23bNgYPHkynTp345S9/Wb5+9uzZ9OrVi+7du3P33Xdz9OiJo2lffPEFQ4YMITMzk65duzJvXtj/oxdpbNSjr8KiRYsYPHgwHTt2pGXLlqxdu5asrCxef/11Fi1axKpVq2jevDl79uyhZcuWPP300zzxxBNkZ2dXed7OnTuzfPlymjZtytKlS/npT3/Kiy++WKOaqjp29erVFBUV0bx5c3r27MmQIUNo0aIF8+bNY+XKlaSkpDB27FjmzJnDiBEjys/5xhtvcP7557N4cWR4bN++fTH+xESkPlLQVyE3N5cHHngAgFtuuYXc3FyysrJYunQpd911F82bNwegZcuWtTrvvn37GDlyJCUlJZgZhw8frpNjr7rqKlq1agXA8OHDWbFiBU2bNqWgoICePXsCcPDgQc4777wTztmtWzfGjRvHQw89xNChQ+nfv3+trkdE6jcF/Sns3r2bt956i6KiIsyMo0ePYmY8/vjjuHuNbhls2rQpx44dAzjhPvKf//znfP/732fhwoWUlpaWD+nURFXHnlyTmeHujBw5kl//+tenPGfHjh0pKCjgtddeY+LEiQwcOJBf/OIXNa5JROo3jdGfwvz58xkxYgQfffQRpaWlbNu2jfbt27NixQoGDhzIzJkz+fLLyCMEe/ZEpgI6++yz2b9/f/k5MjIyKCgoADhhaGbfvn20bRuZGSInJ6dWdVV17JIlS9izZw8HDx5k0aJF9O3blwEDBjB//nx27txZXutHH504s+n27dtp3rw5d9xxB+PGjWPt2rW1qklE6rcG06Ov6e2QdSU3N5cJEyacsO6GG27g+eefZ+rUqRQWFpKdnU2zZs245ppreOyxxxg1ahT33HMPZ555Jn/961+ZNGkSo0eP5rHHHqN3797l53nwwQcZOXIkTz75JFdccUWt6qrq2H79+nHnnXeyefNmbrvttvLPCh555BEGDhzIsWPHSElJ4Xe/+x3t2rUrP+69995j/PjxnHHGGaSkpDB16tTa/rhEpB6zf85ekDzZ2dl+8hePFBcX06VLlyRVJHVNv0+pEd1eWStmVuDuVd/9gYZuRESCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQlcg7mPvs5vu6rB7VRNmjShW7duHDlyhC5dujBr1qzyaQ9qq+JUwy+//DIbNmz42n36x+3du5fnn3+esWPH1qqNhx9+mLPOOotx48bVaH1Fo0aNYujQodx44401aqu0tJShQ4dSVFRUqxpF5PRTj74KZ555JoWFhRQVFdGsWTOmTZt2wnZ3L5/ioDaGDRt2ypCHSND//ve/r/V5RUQqo6Cvof79+7N582ZKS0vp0qULY8eOJSsri23btpGXl0efPn3Iysripptu4sCBA0BkVsjOnTvTr18/FixYUH6unJwc7r33XgB27NjB9ddfT2ZmJpmZmfzlL39hwoQJbNmyhe7duzN+/HgApkyZQs+ePbnooouYNGlS+bkeffRROnXqxJVXXlmj6Y6feeYZevbsSWZmJjfccEP5NA4AS5cupX///nTs2LH8S06OHj3K+PHjy9v+wx/+8LVzvv/+++XTIF900UWUlJTE8BMWkURR0NfAkSNHeP311+nWrRsAmzZtYsSIEaxbt44WLVrwyCOPsHTpUtauXUt2djZPPvkkhw4d4kc/+hGvvPIKf/7zn/n73/9e6bnvu+8+LrvsMt59913Wrl3L9773PSZPnsx3vvMdCgsLmTJlCnl5eZSUlLB69WoKCwspKChg+fLlFBQUMHfuXNatW8eCBQtYs2ZNtdcyfPhw1qxZw7vvvkuXLl2YMeOfXxZWWlrKn/70JxYvXsw999zDoUOHmDFjBueccw5r1qxhzZo1PPPMM3z44YcnnHPatGncf//9FBYWkp+fT3p6ehw/bRGpaw1njD4JDh48SPfu3YFIj3706NFs376ddu3acfHFFwPwzjvvsGHDBvr27QvAV199RZ8+fdi4cSPt27enQ4cOANxxxx1Mnz79a2289dZbPPfcc0DkM4FzzjmHzz777IR98vLyyMvLo0ePHkDkC1FKSkrYv38/119/ffnnBsOGDav2moqKivjZz37G3r17OXDgAIMGDSrf9oMf/IAzzjiDDh06cOGFF7Jx40by8vJYv3498+fPByKTqpWUlNCxY8fy4/r06cOjjz5KWVkZw4cPL79mEakfFPRVOD5Gf7IWLVqUv3d3rrrqKnJzc0/Yp7CwsEZTGdeEuzNx4kTuvvvuE9Y/9dRTtW5j1KhRLFq0iMzMTHJycli2bFn5tlNNc/zb3/72hD8IEOn9H3fbbbfRu3dvFi9ezKBBg3j22WdrPVmbiCSOhm7idPHFF7Ny5Uo2b94MwJdffskHH3xA586d+fDDD9myZQvA1/4QHDdgwIDy2SKPHj3K559//rXpjgcNGsTMmTPLx/7/9re/sXPnTi699FIWLlzIwYMH2b9/P6+88kq19e7fv582bdpw+PBh5syZc8K2P/7xjxw7dowtW7awdetWOnXqxKBBg5g6dWr5F5x88MEHfPHFFycct3XrVi688ELuu+8+hg0bxvr162vyoxOR06Th9Ojr6exyaWlp5OTkcOutt/KPf/wDiEwL3LFjR6ZPn86QIUNo3bo1/fr1q/RWxN/85jeMGTOGGTNm0KRJE6ZOnUqfPn3o27cvXbt25eqrr2bKlCkUFxfTp08fAM466yxmz55NVlYWN998M927d6ddu3Y1+maoX/3qV/Tu3Zt27drRrVu3E/6gdOrUicsuu4wdO3Ywbdo0UlNT+eEPf0hpaSlZWVm4O2lpaSxatOiEc86bN4/Zs2eTkpLCt771LX1piUg9o2mK5bTQ71NqRNMU14qmKRYREUBBLyISvHod9PVhWEnip9+jSHJVG/RmNtPMdppZUYV1Lc1siZmVRF+/EV1vZvbfZrbZzNabWVashaWmprJ7926FRAPn7uzevZvU1NRklyLSaNXkrpsc4GnguQrrJgBvuvtkM5sQXX4IuBroEP3XG5gafa219PR0ysrK2LVrVyyHSz2Smpqqp2VFkqjaoHf35WaWcdLqa4HLo+9nAcuIBP21wHMe6Ya/Y2bnmlkbd/+ktoWlpKTQvn372h4mIiIniXWM/pvHwzv6el50fVtgW4X9yqLrREQkSer6w9jKnsevdJDdzMaYWb6Z5Wt4RkQkcWIN+h1m1gYg+rozur4MuKDCfunA9spO4O7T3T3b3bPT0tJiLENERKoT6xQILwMjgcnR15cqrL/XzOYS+RB2Xyzj81KNZD09CA32CUKRxqzaoDezXCIfvLY2szJgEpGAf8HMRgMfAzdFd38NuAbYDHwJ3JWAmkVEpBZqctfNrafYNKCSfR34cbxFiYhI3anXT8aKiEj8FPQiIoFT0IuIBE5BLyISOAW9iEjgGs5XCYo0Nvq2Jakj6tGLiAROPfoGaGnxjqS1fWXSWhaRWKlHLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgdHuliNQbybp1OPTbhtWjFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnO66EamndAeK1BX16EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJXFxBb2b/z8zeN7MiM8s1s1Qza29mq8ysxMzmmVmzuipWRERqL+agN7O2wH1Atrt3BZoAtwD/CfyXu3cAPgNG10WhIiISm3iHbpoCZ5pZU6A58AlwBTA/un0WcF2cbYiISBxiDnp3/xvwBPAxkYDfBxQAe939SHS3MqBtZceb2Rgzyzez/F27dsVahoiIVCOeoZtvANcC7YHzgRbA1ZXs6pUd7+7T3T3b3bPT0tJiLUNERKoRz9DNlcCH7r7L3Q8DC4BLgHOjQzkA6cD2OGsUEZE4xBP0HwMXm1lzMzNgALABeBu4MbrPSOCl+EoUEZF4xDNGv4rIh65rgfei55oOPAT8xMw2A62AGXVQp4iIxCiuaYrdfRIw6aTVW4Fe8ZxXRETqjp6MFREJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAhfXpGb1wvM3J6/t2+Ylr20RkRpSj15EJHANvke/tHhH0tq+Mmkti4jUnHr0IiKBU9CLiAROQS8iEjgFvYhI4BT0IiKBU9CLiAROQS8iEjgFvYhI4BT0IiKBU9CLiAROQS8iEri4gt7MzjWz+Wa20cyKzayPmbU0syVmVhJ9/UZdFSsiIrUXb4/+N8Ab7t4ZyASKgQnAm+7eAXgzuiwiIkkSc9Cb2b8ClwIzANz9K3ffC1wLzIruNgu4Lt4iRUQkdvH06C8EdgH/Y2brzOxZM2sBfNPdPwGIvp5XB3WKiEiM4gn6pkAWMNXdewBfUIthGjMbY2b5Zpa/a9euOMoQEZGqxBP0ZUCZu6+KLs8nEvw7zKwNQPR1Z2UHu/t0d8929+y0tLQ4yhARkarEHPTu/ndgm5l1iq4aAGwAXgZGRteNBF6Kq0IREYlLvF8l+O/AHDNrBmwF7iLyx+MFMxsNfAzcFGcbIiISh7iC3t0LgexKNg2I57wiIlJ39GSsiEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBC7eB6ZERBq8jAmLk9Z26eQhCW9DPXoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAhd30JtZEzNbZ2avRpfbm9kqMysxs3lm1iz+MkVEJFZ10aO/HyiusPyfwH+5ewfgM2B0HbQhIiIxiivozSwdGAI8G1024ApgfnSXWcB18bQhIiLxibdH/xTwIHAsutwK2OvuR6LLZUDbONsQEZE4xBz0ZjYU2OnuBRVXV7Krn+L4MWaWb2b5u3btirUMERGpRjw9+r7AMDMrBeYSGbJ5CjjXzJpG90kHtld2sLtPd/dsd89OS0uLowwREalKzEHv7hPdPd3dM4BbgLfc/XbgbeDG6G4jgZfirlJERGKWiPvoHwJ+YmabiYzZz0hAGyIiUkNNq9+leu6+DFgWfb8V6FUX5xURkfjpyVgRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAlcnt1eKJFrGhMVJa7t08pCktS1SF9SjFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnGavlAbh2ZQpSWxds1dKw6YevYhI4BT0IiKBU9CLiAROQS8iEjgFvYhI4BT0IiKBiznozewCM3vbzIrN7H0zuz+6vqWZLTGzkujrN+quXBERqa14evRHgP/v7l2Ai4Efm9l3gQnAm+7eAXgzuiwiIkkSc9C7+yfuvjb6fj9QDLQFrgVmRXebBVwXb5EiIhK7OhmjN7MMoAewCvimu38CkT8GwHmnOGaMmeWbWf6uXbvqogwREalE3EFvZmcBLwIPuPvnNT3O3ae7e7a7Z6elpcVbhoiInEJcQW9mKURCfo67L4iu3mFmbaLb2wA74ytRRETiEc9dNwbMAIrd/ckKm14GRkbfjwReir08ERGJVzyzV/YF7gTeM7PC6LqfApOBF8xsNPAxcFN8JYqIJFbos6PGHPTuvgKwU2weEOt5RUSkbunJWBGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCl7CgN7PBZrbJzDab2YREtSMiIlVLSNCbWRPgd8DVwHeBW83su4loS0REqpaoHn0vYLO7b3X3r4C5wLUJaktERKqQqKBvC2yrsFwWXSciIqeZuXvdn9TsJmCQu/8wunwn0Mvd/73CPmOAMdHFTsCmGJtrDXwaR7kNka65cdA1Nw7xXHM7d0+rbqemMZ68OmXABRWW04HtFXdw9+nA9HgbMrN8d8+O9zwNia65cdA1Nw6n45oTNXSzBuhgZu3NrBlwC/BygtoSEZEqJKRH7+5HzOxe4H+BJsBMd38/EW2JiEjVEjV0g7u/BryWqPNXEPfwTwOka24cdM2NQ8KvOSEfxoqISP2hKRBERALXoIO+sU2zYGYzzWynmRUlu5bTxcwuMLO3zazYzN43s/uTXVOimVmqma02s3ej1/zLZNd0OphZEzNbZ2avJruW08HMSs3sPTMrNLP8hLbVUIduotMsfABcReR2zjXAre6+IamFJZCZXQocAJ5z967Jrud0MLM2QBt3X2tmZwMFwHWB/54NaOHuB8wsBVgB3O/u7yS5tIQys58A2cC/uvvQZNeTaGZWCmS7e8KfG2jIPfpGN82Cuy8H9iS7jtPJ3T9x97XR9/uBYgJ/ytojDkQXU6L/GmaPrIbMLB0YAjyb7FpC1JCDXtMsNDJmlgH0AFYlt5LEiw5jFAI7gSXuHvo1PwU8CBxLdiGnkQN5ZlYQnSkgYRpy0Fsl64Lu9TRmZnYW8CLwgLt/nux6Es3dj7p7dyJPlfcys2CH6sxsKLDT3QuSXctp1tfds4jM8vvj6NBsQjTkoK92mgUJQ3Sc+kVgjrsvSHY9p5O77wWWAYOTXEoi9QWGRces5wJXmNns5JaUeO6+Pfq6E1hIZDg6IRpy0GuahUYg+sHkDKDY3Z9Mdj2ng5mlmdm50fdnAlcCG5NbVeK4+0R3T3f3DCL/Hb/l7nckuayEMrMW0ZsLMLMWwEAgYXfTNdigd/cjwPFpFoqBF0KfZsHMcoG/Ap3MrMzMRie7ptOgL3AnkV5eYfTfNckuKsHaAG+b2XoiHZol7t4objlsRL4JrDCzd4HVwGJ3fyNRjTXY2ytFRKRmGmyPXkREakZBLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISOAW9iEjgFPQiIoH7PwrAMEgK1mYgAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(y_test, label='Actual labels');\n",
+    "plt.hist(predicted_labels, label='Predicted labels', alpha=0.7);\n",
+    "plt.legend(loc=0);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Model 3. Logistic regression"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "http://scikit-learn.org/stable/modules/generated/sklearn.linear_model.LogisticRegression.html#sklearn.linear_model.LogisticRegression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from sklearn import linear_model"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "logistic = linear_model.LogisticRegression()\n",
+    "# logrun = logistic.fit(X_train, y_train)\n",
+    "logrun = logistic.fit(X_train_scaled, y_train)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Test accuracy: 0.7995283018867925\n"
+     ]
+    }
+   ],
+   "source": [
+    "predicted_labels = logrun.predict(X_test_scaled)\n",
+    "test_acc = np.sum(predicted_labels == y_test) / len(y_test)\n",
+    "print('Test accuracy:', test_acc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXoAAAD8CAYAAAB5Pm/hAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDIuMi4yLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvhp/UCwAAF1xJREFUeJzt3Xt01OW97/H3F4gHibYWiD0I3SS23LrAhDTcBFFBAQ0HlWq9oAYXW+xCqx43Kna1YletxcuyuraKhwqCRwm0KEhF3UiR7YFWaILsGokIaISIlQCC4SKX8D1/zJANFsJkLgzz5PNaizXzuz7f30Q/efLMb54xd0dERMLVLN0FiIhIainoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwLVIdwEAbdu29dzc3HSXISKSUcrLy7e4e87x9jspgj43N5eysrJ0lyEiklHM7NNY9tPQjYhI4BT0IiKBU9CLiATupBijl8yzf/9+qqur+frrr9NdiiSoZcuWdOjQgaysrHSXIimioJe4VFdXc/rpp5Obm4uZpbsciZO7s3XrVqqrq8nLy0t3OZIiGrqRuHz99de0adNGIZ/hzIw2bdroL7PAKeglbgr5MOjnGD4FvYhI4DRGL0mRO2FBUs9XNak4pv3mzp3LyJEjqayspGvXrg3uO336dIYMGcJZZ50VV01Llizhscce47XXXotp/TfbLisr46mnnoq5vUMfJGzbtm1c9YocoqCXjFZaWsqAAQOYNWsWDzzwQIP7Tp8+ne7du8cd9HICzLw6Pe1eNzs97Z4gGrqRjLVz506WLVvG1KlTmTVr1hHbHnnkEXr06EF+fj4TJkxgzpw5lJWVMWrUKAoKCtizZw+5ubls2bIFgLKyMi644AIAVqxYwbnnnkvPnj0599xzWbNmTcw1NXTsxo0bGTZsGF26dOFXv/pV/foXX3yR3r17U1BQwC233EJdXd0R59y1axfFxcXk5+fTvXt3Zs8OO5Qk+dSjl4w1b948hg0bRufOnWndujUrV66ksLCQN954g3nz5rF8+XJatWrFtm3baN26NU899RSPPfYYRUVFDZ63a9euvPPOO7Ro0YJFixbx85//nJdffjmmmho6dsWKFVRUVNCqVSt69epFcXEx2dnZzJ49m2XLlpGVlcW4ceN46aWXuPHGG+vP+eabb3LWWWexYEFkeGzHjh1xvmLSVCnoJWOVlpZy5513AnDNNddQWlpKYWEhixYt4qabbqJVq1YAtG7dulHn3bFjByUlJaxduxYzY//+/Uk59uKLL6ZNmzYAjBw5kqVLl9KiRQvKy8vp1asXAHv27OHMM8884pw9evRg/Pjx3HvvvQwfPpzzzjuvUdcjoqCXjLR161YWL15MRUUFZkZdXR1mxiOPPIK7x3TLYIsWLTh48CDAEfeR//KXv+TCCy9k7ty5VFVV1Q/pxKKhY79Zk5nh7pSUlPDb3/72mOfs3Lkz5eXlvP7669x3330MGTKE+++/P+aaRDRGLxlpzpw53HjjjXz66adUVVWxceNG8vLyWLp0KUOGDGHatGns3r0bgG3btgFw+umnU1tbW3+O3NxcysvLAY4YmtmxYwft27cHIm/gNkZDx7711lts27aNPXv2MG/ePPr378/gwYOZM2cOmzdvrq/100+PnHl206ZNtGrViuuvv57x48ezcuXKRtUkctwevZlNA4YDm929e3Rda2A2kAtUAT9x9y8t0mV5ErgU2A2Mdnf9V9kExHo7ZLKUlpYyYcKEI9b9+Mc/ZubMmUyePJlVq1ZRVFTEKaecwqWXXspDDz3E6NGj+elPf8qpp57KX//6VyZOnMiYMWN46KGH6NOnT/157rnnHkpKSnj88ccZNGhQo+pq6NgBAwZwww03sG7dOq677rr69woefPBBhgwZwsGDB8nKyuLpp5+mY8eO9ce9//773H333TRr1oysrCwmT57c2JdLmjhz94Z3MBsI7AReOCzoHwG2ufskM5sAfMfd7zWzS4GfEQn6PsCT7t7nWOc+pKioyPXFI5mlsrKSbt26pbsMSZKT5uep2ysbxczK3b3huwuIYejG3d8Btn1j9WXAjOjzGcDlh61/wSPeBc4ws3axly0iIskW7xj9d939c4Do46HbBNoDGw/brzq6TkRE0iTZb8Ye7VaHo44NmdlYMyszs7KampoklyEiIofEG/RfHBqSiT5ujq6vBr532H4dgE1HO4G7T3H3Incvysk57peYi4hInOIN+vlASfR5CfDqYetvtIi+wI5DQzwiIpIesdxeWQpcALQ1s2pgIjAJ+IOZjQE2AFdFd3+dyB0364jcXnlTCmoWEZFGOG7Qu/u1x9g0+Cj7OnBrokVJBkr2bXEx3O7WvHlzevTowYEDB+jWrRszZsyon/agsQ6fanj+/PmsXr36n+7TP2T79u3MnDmTcePGNaqNBx54gNNOO43x48fHtP5wo0ePZvjw4Vx55ZUxtVVVVcXw4cOpqKhoVI0SJk2BIBnr1FNPZdWqVQCMGjWKZ599lrvuuqt+u7vj7jRr1rgRyhEjRjBixIhjbt++fTvPPPNMo4O+0bau/+/ne2uh9h9HrmvIl9VQty/2/XfVwMwHIs8z9J5yOTZNgSBBOO+881i3bh1VVVV069aNcePGUVhYyMaNG1m4cCH9+vWjsLCQq666ip07dwKRWSG7du3KgAEDeOWVV+rPNX36dG677TYAvvjiC6644gry8/PJz8/nL3/5CxMmTGD9+vUUFBRw9913A/Doo4/Sq1cvzjnnHCZOnFh/rt/85jd06dKFiy66KKbpjn//+9/Tq1cv8vPz+fHoW9m9e0/9tkX/+RfOG34NnXtfxGv/sRiAuro67p44iV4XXcE5A4v5P9NL/+mcH3z4Eb0vHknBBf+LcwYWs3Z9VeNfYMlo6tFnonR9ehBOyt7egQMHeOONNxg2bBgAa9as4fnnn+eZZ55hy5YtPPjggyxatIjs7GwefvhhHn/8ce655x5uvvlmFi9ezA9+8AOuvvror+ntt9/O+eefz9y5c6mrq2Pnzp1MmjSJioqK+r8mFi5cyNq1a1mxYgXuzogRI3jnnXfIzs5m1qxZvPfeexw4cIDCwkJ+9KMfNXgtI0eO5OabbwbgF/92K1Nf+iM/uzkyZXHVxmr+c/5M1n+ygQsvH8W68/vzwuy5fPtbp/O3RXPZu3cv/S+9miEXDjhiArVnp5dyx9gSRl11Gfv27aOu7mDCr7lkFgW9ZKw9e/ZQUFAARHr0Y8aMYdOmTXTs2JG+ffsC8O6777J69Wr69+8PwL59++jXrx8ffvgheXl5dOrUCYDrr7+eKVOm/FMbixcv5oUXXgAi7wl8+9vf5ssvvzxin4ULF7Jw4UJ69uwJRL4QZe3atdTW1nLFFVfUv2/Q0HDQIRUVFfziF79g+/bt7PxqO0Mv/O8piX9y2aU0a9aMTt/P5eyO/8KHa9ezcMn/4+8frGHOn94EYMdXtaz9uIrO38+rP65fUU9+87tnqP78H4wsHkqn7+ce/8WVoCjoJWMdPkZ/uOzs7Prn7s7FF19MaemRQxqrVq2KaSrjWLg79913H7fccssR65944olGtzF69GjmzZtHfn4+0596hCXLltdvO/o0x/Dvk+5n6KCBR2yr2lBd//y6K0fQ50f5LHhrCUN/chPP/e4hBg3s16i6JLNpjF6C1rdvX5YtW8a6desA2L17Nx999BFdu3blk08+Yf36yJuV3/xFcMjgwYPrZ4usq6vjq6+++qfpjocOHcq0adPqx/4/++wzNm/ezMCBA5k7dy579uyhtraWP/3pT8ett7a2lnbt2rF//35emjP/iG1/nP8GBw8eZP0nn/Lxpxvo8oOzGXrheUx+fmb9F5x8tO4Tdu3afcRxH1dt4Ozcf+H2sSWMGDaYv6/+MJaXTgKiHr0kx0k4dg+Qk5PD9OnTufbaa9m7dy8QmRa4c+fOTJkyheLiYtq2bcuAAQOOeivik08+ydixY5k6dSrNmzdn8uTJ9OvXj/79+9O9e3cuueQSHn30USorK+nXL9JLPu2003jxxRcpLCzk6quvpqCggI4dO8b0zVC//vWv6dOnDx07dqRHp7Op3bmrfluX7+dx/ojr+GLzFp597Ne0bPk/+NcbfkLVxmoKB12Gu5PTpjXz/u+zR5xz9rwFvPjHV8nKyuJ/ntmW+8fflshLKhnouNMUnwiapriRToI3Y0+aaW1DFuutkUlQ+clndPvo6chCOn9pa5riRol1mmL16DPQosov0tb2RWlrWUTipTF6EZHAKeglbifDsJ8kzt1BP8ugKeglLi1btmTr1q0K+wzn7myt/ZqWe/WdECHTGL3EpUOHDlRXV6MvjUmhXSfgtXWn5d4aOny2IPVtSdoo6CUuWVlZ5OXlHX9Hid+hScZEEqShGxGRwCnoRUQCp6EbETlppOszIqF/PkQ9ehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwOmuG5GTlO5AkWRRj15EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCl1DQm9n/NrMPzKzCzErNrKWZ5ZnZcjNba2azzeyUZBUrIiKNF3fQm1l74HagyN27A82Ba4CHgd+5eyfgS2BMMgoVEZH4JDp00wI41cxaAK2Az4FBwJzo9hnA5Qm2ISIiCYg76N39M+AxYAORgN8BlAPb3f1AdLdqoH2iRYqISPwSGbr5DnAZkAecBWQDlxxlVz/G8WPNrMzMympqTsC33YuINFGJDN1cBHzi7jXuvh94BTgXOCM6lAPQAdh0tIPdfYq7F7l7UU5OTgJliIhIQxIJ+g1AXzNrZWYGDAZWA28DV0b3KQFeTaxEERFJRCJj9MuJvOm6Eng/eq4pwL3AXWa2DmgDTE1CnSIiEqeE5qN394nAxG+s/hjonch5RUQkefTJWBGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCX0DVMng9wJC9LWdtWk4rS1LSISK/XoRUQCl/E9+ueyHk1j6+rRi8jJTz16EZHAKehFRAKnoBcRCZyCXkQkcAp6EZHAKehFRAKnoBcRCZyCXkQkcAp6EZHAKehFRAKnoBcRCVxCQW9mZ5jZHDP70MwqzayfmbU2s7fMbG308TvJKlZERBov0R79k8Cb7t4VyAcqgQnAn929E/Dn6LKIiKRJ3EFvZt8CBgJTAdx9n7tvBy4DZkR3mwFcnmiRIiISv0R69GcDNcDzZvaemT1nZtnAd939c4Do45lHO9jMxppZmZmV1dTUJFCGiIg0JJGgbwEUApPdvSewi0YM07j7FHcvcveinJycBMoQEZGGJBL01UC1uy+PLs8hEvxfmFk7gOjj5sRKFBGRRMQd9O7+D2CjmXWJrhoMrAbmAyXRdSXAqwlVKCIiCUn0qwR/BrxkZqcAHwM3Efnl8QczGwNsAK5KsA0REUlAQkHv7quAoqNsGpzIeUVEJHn0yVgRkcAp6EVEAqegFxEJnIJeRCRwCnoRkcAp6EVEAqegFxEJnIJeRCRwiX4yVkQk4+VOWJC2tqsmFae8DfXoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCl3DQm1lzM3vPzF6LLueZ2XIzW2tms83slMTLFBGReCWjR38HUHnY8sPA79y9E/AlMCYJbYiISJwSCnoz6wAUA89Flw0YBMyJ7jIDuDyRNkREJDGJ9uifAO4BDkaX2wDb3f1AdLkaaJ9gGyIikoC4g97MhgOb3b388NVH2dWPcfxYMyszs7Kampp4yxARkeNIpEffHxhhZlXALCJDNk8AZ5hZi+g+HYBNRzvY3ae4e5G7F+Xk5CRQhoiINCTuoHf3+9y9g7vnAtcAi919FPA2cGV0txLg1YSrFBGRuKXiPvp7gbvMbB2RMfupKWhDRERi1OL4uxyfuy8BlkSffwz0TsZ5RUQkcfpkrIhI4BT0IiKBU9CLiAROQS8iEjgFvYhI4BT0IiKBU9CLiAQuKffRi6Ra7oQFaWm3alJxWtoVSSb16EVEAqcevYg0ec9lPZrG1lP/V6N69CIigVPQi4gETkEvIhI4Bb2ISOAU9CIigVPQi4gETkEvIhI4Bb2ISOAU9CIigVPQi4gETkEvIhI4Bb2ISOAU9CIigVPQi4gETtMUS0ZI3zSy+uIRyXzq0YuIBE5BLyISOAW9iEjgFPQiIoFT0IuIBE5BLyISuLiD3sy+Z2Zvm1mlmX1gZndE17c2s7fMbG308TvJK1dERBorkR79AeDf3L0b0Be41cx+CEwA/uzunYA/R5dFRCRN4g56d//c3VdGn9cClUB74DJgRnS3GcDliRYpIiLxS8oYvZnlAj2B5cB33f1ziPwyAM48xjFjzazMzMpqamqSUYaIiBxFwkFvZqcBLwN3uvtXsR7n7lPcvcjdi3JychItQ0REjiGhoDezLCIh/5K7vxJd/YWZtYtubwdsTqxEERFJRCJ33RgwFah098cP2zQfKIk+LwFejb88ERFJVCKzV/YHbgDeN7NV0XU/ByYBfzCzMcAG4KrEShQRkUTEHfTuvhSwY2weHO95RUQkufTJWBGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCp6AXEQmcgl5EJHAKehGRwCnoRUQCl5KgN7NhZrbGzNaZ2YRUtCEiIrFJetCbWXPgaeAS4IfAtWb2w2S3IyIisUlFj743sM7dP3b3fcAs4LIUtCMiIjFIRdC3BzYetlwdXSciImlg7p7cE5pdBQx193+NLt8A9Hb3n31jv7HA2OhiF2BNnE22BbbEeWym0jU3DbrmpiGRa+7o7jnH26lFnCdvSDXwvcOWOwCbvrmTu08BpiTamJmVuXtRoufJJLrmpkHX3DSciGtOxdDN34BOZpZnZqcA1wDzU9COiIjEIOk9enc/YGa3Af8BNAemufsHyW5HRERik4qhG9z9deD1VJz7KBIe/slAuuamQdfcNKT8mpP+ZqyIiJxcNAWCiEjgMjrom9pUC2Y2zcw2m1lFums5Uczse2b2tplVmtkHZnZHumtKNTNraWYrzOy/otf8q3TXdCKYWXMze8/MXkt3LSeCmVWZ2ftmtsrMylLaVqYO3USnWvgIuJjILZ1/A65199VpLSyFzGwgsBN4wd27p7ueE8HM2gHt3H2lmZ0OlAOXB/5zNiDb3XeaWRawFLjD3d9Nc2kpZWZ3AUXAt9x9eLrrSTUzqwKK3D3lnxvI5B59k5tqwd3fAbalu44Tyd0/d/eV0ee1QCWBf9LaI3ZGF7Oi/zKzRxYjM+sAFAPPpbuWEGVy0GuqhSbGzHKBnsDy9FaSetFhjFXAZuAtdw/9mp8A7gEOpruQE8iBhWZWHp0pIGUyOejtKOuC7vU0ZWZ2GvAycKe7f5XuelLN3evcvYDIJ8t7m1mwQ3VmNhzY7O7l6a7lBOvv7oVEZvq9NTo0mxKZHPQxTbUgmS86Tv0y8JK7v5Luek4kd98OLAGGpbmUVOoPjIiOWc8CBpnZi+ktKfXcfVP0cTMwl8hwdEpkctBrqoUmIPrG5FSg0t0fT3c9J4KZ5ZjZGdHnpwIXAR+mt6rUcff73L2Du+cS+f94sbtfn+ayUsrMsqM3F2Bm2cAQIGV302Vs0Lv7AeDQVAuVwB9Cn2rBzEqBvwJdzKzazMaku6YToD9wA5Fe3qrov0vTXVSKtQPeNrO/E+nQvOXuTeKWwybku8BSM/svYAWwwN3fTFVjGXt7pYiIxCZje/QiIhIbBb2ISOAU9CIigVPQi4gETkEvIhI4Bb2ISOAU9CIigVPQi4gE7v8DfMj/UiLQqZYAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.hist(y_test, label='Actual labels');\n",
+    "plt.hist(predicted_labels, label='Predicted labels', alpha=0.7);\n",
+    "plt.legend(loc=0);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:tf]",
+   "language": "python",
+   "name": "conda-env-tf-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,8 @@ setup(
     name='swsnet',
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    description="Applying neural networks to the Sloan SWS astronomical dataset.",
+    description="Applying neural networks to the \
+                 Sloan SWS astronomical dataset.",
     long_description=readme,
     author="Matt Shannon",
     author_email='matthew.j.shannon@gmail.com',

--- a/swsnet/convert_fits_to_csv.py
+++ b/swsnet/convert_fits_to_csv.py
@@ -46,5 +46,3 @@ for index, fname in enumerate(fits_files):
     # Maybe hold onto the dframes and headers...
     hold_dframes.append(dframe)
     hold_header.append(header)
-
-


### PR DESCRIPTION
Updated the sws data pickles (unzip_me.zip) to include downsampling (from the SWS wavegrid to the CASSIS Spitzer/IRS wavegrid) via SpectRes (https://github.com/ACCarnall/SpectRes).

Created a new ipy notebook using these data. I've also excluded the group=7 (flux free or fatally flawed spectra) from the models. Not sure if these should be included or not. It's introduced by defining meta_clean (pd.dataframe) from meta (pd.dataframe) with the condition group != '7'.